### PR TITLE
docs(projects/rye): rm hatch build hook from workspace project file

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -105,15 +105,11 @@ dev-dependencies = ["polylith-cli"]
 ```
 
 The default build backend for Rye is Hatch.
-Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
 
 ``` toml
 [build-system]
-requires = ["hatchling", "hatch-polylith-bricks"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.build.hooks.polylith-bricks]
-# this section is needed to enable the hook in the build process, even if empty.
 ```
 
 Make Rye (and Hatch) aware of the way Polylith organizes source code:
@@ -124,6 +120,7 @@ dev-mode-dirs = ["components", "bases", "development", "."]
 
 
 ### The project-specific pyproject.toml file(s)
+Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
 ``` toml
 [build-system]
 requires = ["hatchling", "hatch-polylith-bricks"]


### PR DESCRIPTION
This aligns with guidance in:
https://github.com/DavidVujic/python-polylith/issues/198 and
https://github.com/DavidVujic/python-polylith-example-rye/commit/ab029e9d7b1ba0bc1695c5885804ac1ead8aff4b