### PR TITLE
docs: put uv at the top, remove docs for rye

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,6 +5,11 @@
 ## Create a workspace
 This will create a Polylith workspace, with a basic Polylith directory structure.
 
+#### uv
+``` shell
+uv run poly create workspace --name my_example_namespace --theme loose
+```
+
 #### Poetry
 ``` shell
 poetry poly create workspace --name my_example_namespace --theme loose
@@ -18,16 +23,6 @@ hatch run poly create workspace --name my_example_namespace --theme loose
 #### PDM
 ``` shell
 pdm run poly create workspace --name my_example_namespace --theme loose
-```
-
-#### Rye
-``` shell
-rye run poly create workspace --name my_example_namespace --theme loose
-```
-
-#### uv
-``` shell
-uv run poly create workspace --name my_example_namespace --theme loose
 ```
 
 #### Pixi
@@ -98,6 +93,11 @@ These are added for any initial commits of the directory structure, and can safe
 ## Create a component
 This command will create a component - i.e. a Python namespace package.
 
+#### uv
+``` shell
+uv run poly create component --name my_example_component
+```
+
 #### Poetry
 ``` shell
 poetry poly create component --name my_example_component
@@ -111,16 +111,6 @@ hatch run poly create component --name my_example_component
 #### PDM
 ``` shell
 pdm run poly create component --name my_example_component
-```
-
-#### Rye
-``` shell
-rye run poly create component --name my_example_component
-```
-
-#### uv
-``` shell
-uv run poly create component --name my_example_component
 ```
 
 #### Pixi
@@ -145,6 +135,11 @@ It will also be added in the README, when enabled in the configuration. See [con
 ## Create a base
 This command will create a base - i.e. a Python namespace package.
 
+#### uv
+``` shell
+uv run poly create base --name my_example_base
+```
+
 #### Poetry
 ``` shell
 poetry poly create base --name my_example_base
@@ -158,16 +153,6 @@ hatch run poly create base --name my_example_base
 #### PDM
 ``` shell
 pdm run poly create base --name my_example_base
-```
-
-#### Rye
-``` shell
-rye run poly create base --name my_example_base
-```
-
-#### uv
-``` shell
-uv run poly create base --name my_example_base
 ```
 
 #### Pixi
@@ -192,6 +177,11 @@ It will also be added in the README, when enabled in the configuration. See [con
 ## Create a project
 This command will create a project - i.e. a pyproject.toml in a project directory.
 
+#### uv
+``` shell
+uv run poly create project --name my_example_project
+```
+
 #### Poetry
 ``` shell
 poetry poly create project --name my_example_project
@@ -205,16 +195,6 @@ hatch run poly create project --name my_example_project
 #### PDM
 ``` shell
 pdm run poly create project --name my_example_project
-```
-
-#### Rye
-``` shell
-rye run poly create project --name my_example_project
-```
-
-#### uv
-``` shell
-uv run poly create project --name my_example_project
 ```
 
 #### Pixi
@@ -239,6 +219,11 @@ poly create project --name my_example_project
 ## Info
 Show info about the workspace:
 
+#### uv
+``` shell
+uv run poly info
+```
+
 #### Poetry
 ``` shell
 poetry poly info
@@ -252,16 +237,6 @@ hatch run poly info
 #### PDM
 ``` shell
 pdm run poly info
-```
-
-#### Rye
-``` shell
-rye run poly info
-```
-
-#### uv
-``` shell
-uv run poly info
 ```
 
 #### Pixi
@@ -295,6 +270,11 @@ The pattern can be configured in the Workspace [configuration](configuration.md)
 The `diff` command is useful in a CI environment, to determine if a project should be deployed or not.
 It is also useful when running tests for changed bricks only.
 
+#### uv
+``` shell
+uv run poly diff
+```
+
 #### Poetry
 ``` shell
 poetry poly diff
@@ -308,16 +288,6 @@ hatch run poly diff
 #### PDM
 ``` shell
 pdm run poly diff
-```
-
-#### Rye
-``` shell
-rye run poly diff
-```
-
-#### uv
-``` shell
-uv run poly diff
 ```
 
 #### Pixi
@@ -347,6 +317,11 @@ This option also support using a specific commit hash.
 ## Libs
 Show info about the third-party libraries used in the workspace:
 
+#### uv
+``` shell
+uv run poly libs
+```
+
 #### Poetry
 ``` shell
 poetry poly libs
@@ -366,16 +341,6 @@ hatch run poly libs
 #### PDM
 ``` shell
 pdm run poly libs
-```
-
-#### Rye
-``` shell
-rye run poly libs
-```
-
-#### uv
-``` shell
-uv run poly libs
 ```
 
 #### Pixi
@@ -412,6 +377,11 @@ Using `--alias opencv-python=cv2` will make the command treat the alias as a thi
 ## Check
 Validates the Polylith workspace, checking for any missing dependencies (bricks and third-party libraries):
 
+#### uv
+``` shell
+uv run poly check
+```
+
 #### Poetry
 ``` shell
 poetry poly check
@@ -428,16 +398,6 @@ hatch run poly check
 #### PDM
 ``` shell
 pdm run poly check
-```
-
-#### Rye
-``` shell
-rye run poly check
-```
-
-#### uv
-``` shell
-uv run poly check
 ```
 
 #### Pixi
@@ -474,6 +434,11 @@ Using `--alias opencv-python=cv2` will make the command treat the alias as a thi
 ## Sync
 Keep projects in sync with the actual usage of bricks in source code.
 
+#### uv
+``` shell
+uv run poly sync
+```
+
 #### Poetry
 ``` shell
 poetry poly sync
@@ -487,16 +452,6 @@ hatch run poly sync
 #### PDM
 ``` shell
 pdm run poly sync
-```
-
-#### Rye
-``` shell
-rye run poly sync
-```
-
-#### uv
-``` shell
-uv run poly sync
 ```
 
 #### Pixi
@@ -525,6 +480,11 @@ Synchronize a specific project.
 ## Deps
 Show dependencies between bricks.
 
+#### uv
+``` shell
+uv run poly deps
+```
+
 #### Poetry
 ``` shell
 poetry poly deps
@@ -538,16 +498,6 @@ hatch run poly deps
 #### PDM
 ``` shell
 pdm run poly deps
-```
-
-#### Rye
-``` shell
-rye run poly deps
-```
-
-#### uv
-``` shell
-uv run poly deps
 ```
 
 #### Pixi
@@ -590,6 +540,11 @@ It will show you any affected bricks or projects a test is modified.
 Tests are expected to live in a test directory at the Workspace root when using the recommended __loose__ theme.
 For users of the __tdd__ theme, the tests are expected to be found in the brick test directory.
 
+#### uv
+``` shell
+uv run poly test diff
+```
+
 #### Poetry
 ``` shell
 poetry poly test diff
@@ -603,16 +558,6 @@ hatch run poly test diff
 #### PDM
 ``` shell
 pdm run poly test diff
-```
-
-#### Rye
-``` shell
-rye run poly test diff
-```
-
-#### uv
-``` shell
-uv run poly test diff
 ```
 
 #### Pixi

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -27,6 +27,11 @@ Use the `poly libs` and/or `poly check` [command](commands.md) to verify all tha
 Both commands support the `--directory` option (coming from Poetry).
 This means that you can run the commands from the workspace root, but for a specific project:
 
+### uv
+``` shell
+uv run poly check --directory projects/my-project
+```
+
 ### Poetry
 ``` shell
 poetry poly check --directory projects/my-project
@@ -40,16 +45,6 @@ hatch run poly check --directory projects/my-project
 ### PDM
 ``` shell
 pdm run poly check --directory projects/my-project
-```
-
-### Rye
-``` shell
-rye run poly check --directory projects/my-project
-```
-
-### uv
-``` shell
-uv run poly check --directory projects/my-project
 ```
 
 ### Maturin

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,7 +16,7 @@ you will need to add the path in the project-specific `pyroject.toml`.
 
 If you only provide `wheel` distributions, this is optional.
 
-#### Hatch, Rye, Pixi and uv
+#### uv, Hatch and Pixi
 ```toml
 [tool.hatch.build.targets.wheel]
 packages = ["<your top namespace here>"]
@@ -42,6 +42,11 @@ This is the preferred way for Polylith projects.
 
 ### Packaging a service or app
 
+#### uv
+``` shell
+uv build --wheel projects/the_project
+```
+
 #### Poetry
 ``` shell
 poetry build-project --directory projects/the_project
@@ -59,18 +64,6 @@ hatch build
 cd projects/the_project
 
 pdm build
-```
-
-#### Rye
-``` shell
-cd projects/the_project
-
-rye build --wheel
-```
-
-#### uv
-``` shell
-uv build --wheel projects/the_project
 ```
 
 _Are you using the `uv` build backend (and not the recommended `hatch` build backend)?_
@@ -129,7 +122,7 @@ The `build-project` command, with a custom top namespace:
 poetry build-project --with-top-namespace my_custom_namespace
 ```
 
-#### uv, Hatch, PDM, Rye and Maturin
+#### uv, Hatch, PDM and Maturin
 A custom top namespace is defined in the project-specific `pyproject.toml`:
 
 ``` toml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,12 +4,12 @@
 Here are some examples of how to setup __Python__ with the Polylith Architecture.
 
 - Python Polylith Example Monorepo
+    - [for uv](https://github.com/DavidVujic/python-polylith-example-uv)
     - [for Poetry](https://github.com/DavidVujic/python-polylith-example)
     - [for Hatch](https://github.com/DavidVujic/python-polylith-example-hatch)
     - [for PDM](https://github.com/DavidVujic/python-polylith-example-pdm)
     - [for Rye](https://github.com/DavidVujic/python-polylith-example-rye)
     - [for Pants](https://github.com/DavidVujic/python-polylith-example-pants)
-    - [for uv](https://github.com/DavidVujic/python-polylith-example-uv)
     - [for Pixi](https://github.com/FloLangenfeld/python-polylith-example-with-pixi) by Florent Langenfeld
 - [Python Polylith Microservices Example](https://github.com/ttamg/python-polylith-microservices-example) by Matt Gosden
 - [Aws CDK App with Polylith](https://github.com/ybenitezf/cdk_polylith) by Yoel Benítez Fonseca

--- a/docs/ide.md
+++ b/docs/ide.md
@@ -61,7 +61,7 @@ path = ".venv"
 ## PyCharm
 Make sure that you have a local virtual environment configuration (see above).
 
-Run `poetry install` or `hatch env create` in a shell.
+Run `uv sync`, `poetry install` or `hatch env create` in a shell.
 
 This will install the dependencies, and make the environment aware of the `bases` and `components` directories.
 PyCharm will ask about what interpreter to use when opening a Python file. Make sure to choose the local one in the `.venv` directory.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,12 @@
 
 # Installation
 
+## uv, Hatch, PDM, Pantsbuild, Maturin and Pixi
+
+No globally added tools needed. Add the project-specific dependencies (see the [Setup](setup.md) and [Projects & pyproject.toml](projects.md) section),
+and the build hook plugins to add support for the Polylith structure and when packaging libraries.
+
+
 ## Poetry
 ### Add Poetry plugins
 With the `Poetry` version 1.2 or later installed, you can add plugins. First, add the [Multiproject](https://github.com/DavidVujic/poetry-multiproject-plugin) plugin,
@@ -15,8 +21,3 @@ poetry self add poetry-polylith-plugin
 ```
 
 Done!
-
-## uv, Hatch, PDM, Rye, Pantsbuild, Maturin and Pixi
-
-No globally added tools needed. Add the project-specific dependencies (see the [Setup](setup.md) and [Projects & pyproject.toml](projects.md) section),
-and the build hook plugins to add support for the Polylith structure and when packaging libraries.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -22,7 +22,7 @@ packages = [
 # insert the needed 3rd party libraries here
 ```
 
-## uv, Hatch, PDM, Rye and Maturin
+## uv, Hatch, PDM and Maturin
 ``` toml
 [project]
 dependencies = [] # insert the needed 3rd party libraries here
@@ -48,6 +48,13 @@ Continue with your next existing service or app! By now, you should already be a
 ## Migrating away from Polylith?
 This step is simple.
 
+### uv
+``` shell
+cd path/to_project
+
+uv build
+```
+
 ### Poetry
 ``` shell
 poetry build-project --directory path/to/project
@@ -65,20 +72,6 @@ hatch build
 cd path/to/project
 
 pdm build
-```
-
-### Rye
-``` shell
-cd path/to_project
-
-rye build --sdist
-```
-
-### uv
-``` shell
-cd path/to_project
-
-uv build
 ```
 
 ### Maturin

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,9 +1,64 @@
 # Projects & pyproject.toml
 
 Projects are located in the _projects_ directory of a Polylith workspace. Each project has its own `pyproject.toml`,
-where dependencies and project-specific things are defined. Just as in a mainstream __Poetry__ or __Hatch__ project.
+where dependencies and project-specific things are defined. Just as in a mainstream __uv__,  __Poetry__ or __Hatch__ project.
 
 What differs is how the Polylith components and bases (aka bricks) are referenced. 
+
+## uv
+
+### The pyproject.toml in the Workspace (i.e. the one in the root directory)
+Add the `polylith-cli` to the workspace `pyproject.toml` configuration.
+
+Add it manually, or by running `uv add polylith-cli --dev`:
+
+``` toml
+[tool.uv]
+dev-dependencies = ["polylith-cli"]
+```
+
+The default build backend for uv is Hatch.
+
+``` toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+Make uv (and Hatch) aware of the way Polylith organizes source code:
+``` toml
+[tool.hatch.build]
+dev-mode-dirs = ["components", "bases", "development", "."]
+```
+
+
+### The project-specific pyproject.toml file(s)
+Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
+``` toml
+[build-system]
+requires = ["hatchling", "hatch-polylith-bricks"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.polylith-bricks]
+# this section is needed to enable the hook in the build process, even if empty.
+
+# This section is needed for building
+[tool.hatch.build.targets.wheel]
+packages = ["<the polylith top namespace here>"]
+```
+
+Polylith bricks are added in the `[tool.polylith.bricks]` section:
+
+``` toml
+[tool.polylith.bricks]
+"../../bases/my_namespace/my_base" = "my_namespace/my_base"
+"../../components/my_namespace/my_component" = "my_namespace/my_component"
+"../../components/my_namespace/my_other_component" = "my_namespace/my_other_component"
+```
+
+The `bases` and `components` directories are located at the workspace root.
+The project-specific `pyproject.toml` file is located in a subdirectory of `projects`.
+
 
 ## Poetry
 Bricks are added in the _tool.poetry_ section as _packages_:
@@ -95,115 +150,6 @@ Polylith bricks are added in the `[tool.polylith.bricks]` section:
 "../../components/my_namespace/my_component" = "my_namespace/my_component"
 "../../components/my_namespace/my_other_component" = "my_namespace/my_other_component"
 ```
-
-## Rye
-
-### The pyproject.toml in the Workspace (i.e. the one in the root directory)
-Add the `polylith-cli` to the workspace `pyproject.toml` configuration.
-
-Add it manually, or by running `rye add polylith-cli --dev`:
-
-``` toml
-[tool.rye]
-dev-dependencies = ["polylith-cli"]
-```
-
-The default build backend for Rye is Hatch.
-
-``` toml
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-```
-
-Make Rye (and Hatch) aware of the way Polylith organizes source code:
-``` toml
-[tool.hatch.build]
-dev-mode-dirs = ["components", "bases", "development", "."]
-```
-
-
-### The project-specific pyproject.toml file(s)
-Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
-``` toml
-[build-system]
-requires = ["hatchling", "hatch-polylith-bricks"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.hooks.polylith-bricks]
-# this section is needed to enable the hook in the build process, even if empty.
-
-# This section is needed for building
-[tool.hatch.build.targets.wheel]
-packages = ["<the polylith top namespace here>"]
-```
-
-Polylith bricks are added in the `[tool.polylith.bricks]` section:
-
-``` toml
-[tool.polylith.bricks]
-"../../bases/my_namespace/my_base" = "my_namespace/my_base"
-"../../components/my_namespace/my_component" = "my_namespace/my_component"
-"../../components/my_namespace/my_other_component" = "my_namespace/my_other_component"
-```
-
-The `bases` and `components` directories are located at the workspace root.
-The project-specific `pyproject.toml` file is located in a subdirectory of `projects`.
-
-## uv
-
-### The pyproject.toml in the Workspace (i.e. the one in the root directory)
-Add the `polylith-cli` to the workspace `pyproject.toml` configuration.
-
-Add it manually, or by running `uv add polylith-cli --dev`:
-
-``` toml
-[tool.uv]
-dev-dependencies = ["polylith-cli"]
-```
-
-The default build backend for uv is Hatch.
-
-``` toml
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-```
-
-Make uv (and Hatch) aware of the way Polylith organizes source code:
-``` toml
-[tool.hatch.build]
-dev-mode-dirs = ["components", "bases", "development", "."]
-```
-
-
-### The project-specific pyproject.toml file(s)
-Add the `hatch-polylith-bricks` build hook plugin to the `pyproject.toml` file.
-``` toml
-[build-system]
-requires = ["hatchling", "hatch-polylith-bricks"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.hooks.polylith-bricks]
-# this section is needed to enable the hook in the build process, even if empty.
-
-# This section is needed for building
-[tool.hatch.build.targets.wheel]
-packages = ["<the polylith top namespace here>"]
-```
-
-Polylith bricks are added in the `[tool.polylith.bricks]` section:
-
-``` toml
-[tool.polylith.bricks]
-"../../bases/my_namespace/my_base" = "my_namespace/my_base"
-"../../components/my_namespace/my_component" = "my_namespace/my_component"
-"../../components/my_namespace/my_other_component" = "my_namespace/my_other_component"
-```
-
-The `bases` and `components` directories are located at the workspace root.
-The project-specific `pyproject.toml` file is located in a subdirectory of `projects`.
-
 
 ## Maturin
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,11 +1,71 @@
 # Setup
 
 ##  Create a Polylith Workspace
-Create a directory for your code, initialize it with __git__ and create a basic __Poetry__, __Hatch__ or __PDM__ setup:
+Create a directory for your code, initialize it with __git__ and create a basic __uv__,  __Poetry__, __Hatch__,  __PDM__, __Maturin__ or __pixi__ setup:
 
 ``` shell
 git init
 ```
+
+### uv
+``` shell
+uv init my_repo  # name your repo
+
+cd my_repo
+
+uv add polylith-cli --dev
+
+uv sync  # create a virtual environment and lock files
+```
+
+Create a workspace, with a basic Polylith directory structure.
+
+``` shell
+uv run poly create workspace --name my_namespace --theme loose
+```
+
+`--name` (required) the workspace name, that will be used as the single top namespace for all bricks.
+__Choose the name wisely.__ Have a look in [PEP-423](https://peps.python.org/pep-0423/#respect-ownership) for naming guidelines.
+
+`--theme` the structure of the workspace, `loose` is the recommended structure for Python.
+
+#### Edit the project configuration
+The recommended build backend for `uv` is Hatch. This is because of the very useful build hook support.
+Make sure to add this section, if not already added, in the `pyproject.toml`:
+
+``` toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+Make `uv` aware of the way Polylith organizes source code:
+``` toml
+[tool.hatch.build]
+dev-mode-dirs = ["components", "bases", "development", "."]
+```
+
+Run the `sync` command to update the virtual environment:
+
+``` shell
+uv sync
+```
+
+##### What about the uv Build Backend?
+You can use the `uv` build backend with Polylith, even if the `hatch` backend is the recommended one.
+
+Add this configuration, to make `uv` aware of namespace packages and the top namespace.
+
+``` toml
+[tool.uv.build-backend]
+namespace = true
+module-name = "<the polylith top namespace here>"
+module-root = ""
+```
+
+Also, have a look at the `poly env` command to make sure the "dev mode dirs", or _module roots_, are in sync with
+the current virtual environment.
+
 
 ### Poetry
 ``` shell
@@ -124,112 +184,6 @@ pdm run poly create workspace --name my_namespace --theme loose
 __Choose the name wisely.__ Have a look in [PEP-423](https://peps.python.org/pep-0423/#respect-ownership) for naming guidelines.
 
 `--theme` the structure of the workspace, `loose` is the recommended structure for Python.
-
-
-### Rye
-``` shell
-rye init my_repo  # name your repo
-
-cd my_repo
-
-rye add polylith-cli --dev
-
-rye sync  # create a virtual environment and lock files
-```
-
-Create a workspace, with a basic Polylith directory structure.
-
-``` shell
-rye run poly create workspace --name my_namespace --theme loose
-```
-
-`--name` (required) the workspace name, that will be used as the single top namespace for all bricks.
-__Choose the name wisely.__ Have a look in [PEP-423](https://peps.python.org/pep-0423/#respect-ownership) for naming guidelines.
-
-`--theme` the structure of the workspace, `loose` is the recommended structure for Python.
-
-
-#### Edit the configuration
-The default build backend for Rye is Hatch.
-Make Rye (and Hatch) aware of the way Polylith organizes source code:
-``` toml
-[tool.hatch.build]
-dev-mode-dirs = ["components", "bases", "development", "."]
-```
-
-Remove the `[tool.hatch.build.targets.wheel]` section.
-
-Run the `sync` command to update the virtual environment:
-
-``` shell
-rye sync
-```
-
-Finally, remove the `src` boilerplate code that was added by Rye in the first step:
-``` shell
-rm -r src
-```
-
-### uv
-``` shell
-uv init my_repo  # name your repo
-
-cd my_repo
-
-uv add polylith-cli --dev
-
-uv sync  # create a virtual environment and lock files
-```
-
-> :material-information: as an alternative to adding a dev dependency, it is also possible to use uvx (example usage: `uvx --from polylith-cli poly info`).
-
-Create a workspace, with a basic Polylith directory structure.
-
-``` shell
-uv run poly create workspace --name my_namespace --theme loose
-```
-
-`--name` (required) the workspace name, that will be used as the single top namespace for all bricks.
-__Choose the name wisely.__ Have a look in [PEP-423](https://peps.python.org/pep-0423/#respect-ownership) for naming guidelines.
-
-`--theme` the structure of the workspace, `loose` is the recommended structure for Python.
-
-#### Edit the project configuration
-The recommended build backend for `uv` is Hatch. This is because of the very useful build hook support.
-Make sure to add this section, if not already added, in the `pyproject.toml`:
-
-``` toml
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-```
-
-Make `uv` aware of the way Polylith organizes source code:
-``` toml
-[tool.hatch.build]
-dev-mode-dirs = ["components", "bases", "development", "."]
-```
-
-Run the `sync` command to update the virtual environment:
-
-``` shell
-uv sync
-```
-
-##### What about the uv Build Backend?
-You can use the `uv` build backend with Polylith, even if the `hatch` backend is the recommended one.
-
-Add this configuration, to make `uv` aware of namespace packages and the top namespace.
-
-``` toml
-[tool.uv.build-backend]
-namespace = true
-module-name = "<the polylith top namespace here>"
-module-root = ""
-```
-
-Also, have a look at the `poly env` command to make sure the "dev mode dirs", or _module roots_, are in sync with
-the current virtual environment.
 
 ### Maturin
 Add the `polylith-cli` as a development dependency to your `pyproject.toml` file:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,11 @@ Add the proper assertions to your tests during development of the bricks.
 ## Running tests
 Running Pytest from the workspace root:
 
+#### uv
+``` shell
+uv run pytest
+```
+
 #### Poetry
 ``` shell
 poetry run pytest
@@ -36,16 +41,6 @@ hatch run pytest
 #### PDM
 ``` shell
 pdm run pytest
-```
-
-#### Rye
-``` shell
-rye run pytest
-```
-
-#### uv
-``` shell
-uv run pytest
 ```
 
 #### Maturin
@@ -118,6 +113,11 @@ Append the `--short` option for a scripting-friendly output.
 You can use the output from the `poly diff` command to run specific tests.
 Storing a list of bricks in a bash variable:
 
+#### uv
+``` shell
+changes="$(uv run poly diff --bricks --short)"
+```
+
 #### Poetry
 ``` shell
 changes="$(poetry poly diff --bricks --short)"
@@ -131,16 +131,6 @@ changes="$(hatch run poly diff --bricks --short)"
 #### PDM
 ``` shell
 changes="$(pdm run poly diff --bricks --short)"
-```
-
-#### Rye
-``` shell
-changes="$(rye run poly diff --bricks --short)"
-```
-
-#### uv
-``` shell
-changes="$(uv run poly diff --bricks --short)"
 ```
 
 #### Maturin
@@ -166,6 +156,13 @@ Transform the result of the `poly diff` command into a Pytest _keyword_ or _mark
 - `-k` is for running tests by keyword expressions.
 - `-m` is for running tests by marker expressions.
 
+#### uv
+``` shell
+query="${changes//,/ or }"
+
+uv run pytest -k <<< echo "$query"
+```
+
 #### Poetry
 ``` shell
 query="${changes//,/ or }"
@@ -185,20 +182,6 @@ hatch run pytest -k <<< echo "$query"
 query="${changes//,/ or }"
 
 pdm run pytest -k <<< echo "$query"
-```
-
-#### Rye
-``` shell
-query="${changes//,/ or }"
-
-rye run pytest -k <<< echo "$query"
-```
-
-#### uv
-``` shell
-query="${changes//,/ or }"
-
-uv run pytest -k <<< echo "$query"
 ```
 
 #### Maturin


### PR DESCRIPTION
Removing docs for _Rye_, because the _Rye_ repo is archived and no development has been done since 2025: https://github.com/astral-sh/rye

Put the `uv`-specific docs at the top of the different package & dependency management tools since it nowadays is the most common tool to use with Polylith.